### PR TITLE
project: run script to build prod docker image

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,10 @@
   "name": "reflex",
   "version": "1.0.0",
   "scripts": {
+    "docker-image": "docker build -t reflexgamers/reflex:$(git rev-parse HEAD) .",
     "postinstall": "tsc -p ./src",
-    "watch": "tsc -w -p ./src",
-    "start": "node ./dist/index.js"
+    "start": "node ./dist/index.js",
+    "watch": "tsc -w -p ./src"
   },
   "description": "Bot to manage Reflex Gamers Discord",
   "main": "index.js",


### PR DESCRIPTION
The script will build a docker image tagged for use in the production
hub repository. We use the git SHA of the latest commit for the tag.

closes #1